### PR TITLE
fix(docs): update image paths

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -89,7 +89,7 @@ export default defineConfig({
 						{ label: 'Access to Prometheus metrics', slug: 'configuration/prometheus-metrics', translations: { ru: 'Доступ к метрикам Prometheus' } },
 						{ label: 'External access to API', slug: 'configuration/external-api', translations: { ru: 'Внешний доступ к API' } },
 						{ label: 'Monitoring with Grafana', slug: 'configuration/grafana-monitoring', translations: { ru: 'Мониторинг через Grafana' } },
-						{ label: 'NetBird', slug: 'configuration/netbird', translations: { ru: 'Netbird' }, badge: {text: '🎉 New', variant: 'default'} },
+						{ label: 'Netbird', slug: 'configuration/netbird', translations: { ru: 'Netbird' }, badge: {text: '🎉 New', variant: 'default'} },
 						{ label: 'Warp Native', slug: 'configuration/warp-native', translations: { ru: 'Warp Native' }, badge: {text: '🎉 New', variant: 'default'} },
 					],
 				},

--- a/docs/src/content/docs/configuration/netbird.mdx
+++ b/docs/src/content/docs/configuration/netbird.mdx
@@ -22,7 +22,7 @@ Netbird is an open-source platform based on WireGuard that allows you to easily 
 
     <div style={{ display: 'flex', justifyContent: 'center' }}>
       <img 
-        src="https://raw.githubusercontent.com/eGamesAPI/remnawave-reverse-proxy/refs/heads/main/docs/src/assets/ru/netbird/register.png" 
+        src="https://raw.githubusercontent.com/eGamesAPI/remnawave-reverse-proxy/refs/heads/main/docs/src/assets/netbird/register.png" 
         alt="Netbird registration" 
         style={{ maxWidth: '60%' }} 
       />
@@ -34,7 +34,7 @@ Netbird is an open-source platform based on WireGuard that allows you to easily 
 
 5. After this, you will be taken to the Netbird Dashboard.
 
-    ![Netbird peer](https://raw.githubusercontent.com/eGamesAPI/remnawave-reverse-proxy/refs/heads/main/docs/src/assets/ru/netbird/peer.png)
+    ![Netbird peer](https://raw.githubusercontent.com/eGamesAPI/remnawave-reverse-proxy/refs/heads/main/docs/src/assets/netbird/peer.png)
 
 </Steps>
 
@@ -44,13 +44,13 @@ Netbird is an open-source platform based on WireGuard that allows you to easily 
 
 1. Go to the Setup Keys section. Click the Create Setup Key button.
 
-    ![Netbird setup key](https://raw.githubusercontent.com/eGamesAPI/remnawave-reverse-proxy/refs/heads/main/docs/src/assets/ru/netbird/setup_key.png)
+    ![Netbird setup key](https://raw.githubusercontent.com/eGamesAPI/remnawave-reverse-proxy/refs/heads/main/docs/src/assets/netbird/setup_key.png)
 
 2. Create the key.
 
     <div style={{ display: 'flex', justifyContent: 'center' }}>
       <img 
-        src="https://raw.githubusercontent.com/eGamesAPI/remnawave-reverse-proxy/refs/heads/main/docs/src/assets/ru/netbird/create_new_setup_key.png" 
+        src="https://raw.githubusercontent.com/eGamesAPI/remnawave-reverse-proxy/refs/heads/main/docs/src/assets/netbird/create_new_setup_key.png" 
         alt="Netbird create new setup key" 
         style={{ maxWidth: '60%' }} 
       />
@@ -68,7 +68,7 @@ Netbird is an open-source platform based on WireGuard that allows you to easily 
 
     <div style={{ display: 'flex', justifyContent: 'center' }}>
       <img 
-        src="https://raw.githubusercontent.com/eGamesAPI/remnawave-reverse-proxy/refs/heads/main/docs/src/assets/ru/netbird/key.png" 
+        src="https://raw.githubusercontent.com/eGamesAPI/remnawave-reverse-proxy/refs/heads/main/docs/src/assets/netbird/key.png" 
         alt="Netbird key" 
         style={{ maxWidth: '60%' }} 
       />
@@ -88,7 +88,7 @@ Netbird is an open-source platform based on WireGuard that allows you to easily 
 
     <div style={{ display: 'flex', justifyContent: 'center' }}>
       <img 
-        src="https://raw.githubusercontent.com/eGamesAPI/remnawave-reverse-proxy/refs/heads/main/docs/src/assets/ru/netbird/install_netbird.png" 
+        src="https://raw.githubusercontent.com/eGamesAPI/remnawave-reverse-proxy/refs/heads/main/docs/src/assets/netbird/install_netbird.png" 
         alt="Netbird create setup key" 
         style={{ maxWidth: '75%' }} 
       />
@@ -100,7 +100,7 @@ Netbird is an open-source platform based on WireGuard that allows you to easily 
     curl -fsSL https://pkgs.netbird.io/install.sh | sh
     ```
 
-    ![Netbird setup](https://raw.githubusercontent.com/eGamesAPI/remnawave-reverse-proxy/refs/heads/main/docs/src/assets/ru/netbird/setup_netbird.png)
+    ![Netbird setup](https://raw.githubusercontent.com/eGamesAPI/remnawave-reverse-proxy/refs/heads/main/docs/src/assets/netbird/setup_netbird.png)
 
 3. Start Netbird with the key. Run the command to connect using your saved key:
 
@@ -108,7 +108,7 @@ Netbird is an open-source platform based on WireGuard that allows you to easily 
     netbird up --setup-key AE53280D-88CC-4250-9228-401AB1C7C041
     ```
 
-    ![Netbird setup](https://raw.githubusercontent.com/eGamesAPI/remnawave-reverse-proxy/refs/heads/main/docs/src/assets/ru/netbird/setup_netbird2.png)
+    ![Netbird setup](https://raw.githubusercontent.com/eGamesAPI/remnawave-reverse-proxy/refs/heads/main/docs/src/assets/netbird/setup_netbird2.png)
 
 4. Wait for the `Connected` message, indicating a successful connection.
 
@@ -120,7 +120,7 @@ Return to the Dashboard and go to the Peers section.
 
 Ensure that the Remnawave panel peer is shown as connected.
 
-![Netbird peer](https://raw.githubusercontent.com/eGamesAPI/remnawave-reverse-proxy/refs/heads/main/docs/src/assets/ru/netbird/peer_netbird.png)
+![Netbird peer](https://raw.githubusercontent.com/eGamesAPI/remnawave-reverse-proxy/refs/heads/main/docs/src/assets/netbird/peer_netbird.png)
 
 ## Installing Netbird on the Node Server
 
@@ -128,7 +128,7 @@ Follow the same installation steps as on the panel server.
 
 Return to the Dashboard and go to the Peers section. Ensure that the node peer is shown as connected.
 
-![Netbird peer](https://raw.githubusercontent.com/eGamesAPI/remnawave-reverse-proxy/refs/heads/main/docs/src/assets/ru/netbird/peer_netbird_node.png)
+![Netbird peer](https://raw.githubusercontent.com/eGamesAPI/remnawave-reverse-proxy/refs/heads/main/docs/src/assets/netbird/peer_netbird_node.png)
 
 ## Configuring the Firewall (UFW) on the Node Server
 
@@ -157,7 +157,7 @@ ufw reload
 
     <div style={{ display: 'flex', justifyContent: 'center' }}>
       <img 
-        src="https://raw.githubusercontent.com/eGamesAPI/remnawave-reverse-proxy/refs/heads/main/docs/src/assets/ru/netbird/ip_netbird_node.png" 
+        src="https://raw.githubusercontent.com/eGamesAPI/remnawave-reverse-proxy/refs/heads/main/docs/src/assets/netbird/ip_netbird_node.png" 
         alt="Netbird create setup key" 
         style={{ maxWidth: '75%' }} 
       />
@@ -169,7 +169,7 @@ ufw reload
 
 ## Verifying the Connection
 
-![Netbird peer](https://raw.githubusercontent.com/eGamesAPI/remnawave-reverse-proxy/refs/heads/main/docs/src/assets/ru/netbird/ip_netbird_node1.png)
+![Netbird peer](https://raw.githubusercontent.com/eGamesAPI/remnawave-reverse-proxy/refs/heads/main/docs/src/assets/netbird/ip_netbird_node1.png)
 
 The node is now connected to the Remnawave panel via Netbird.
 Ensure that the connection between the panel and the node is working (e.g., check access via IP with ping or SSH).

--- a/docs/src/content/docs/configuration/netbird.mdx
+++ b/docs/src/content/docs/configuration/netbird.mdx
@@ -22,7 +22,7 @@ Netbird is an open-source platform based on WireGuard that allows you to easily 
 
     <div style={{ display: 'flex', justifyContent: 'center' }}>
       <img 
-        src="https://raw.githubusercontent.com/eGamesAPI/remnawave-reverse-proxy/refs/heads/main/docs/src/assets/netbird/register.png" 
+        src="https://raw.githubusercontent.com/eGamesAPI/remnawave-reverse-proxy/refs/heads/main/docs/src/assets/en/netbird/register.png" 
         alt="Netbird registration" 
         style={{ maxWidth: '60%' }} 
       />
@@ -34,7 +34,7 @@ Netbird is an open-source platform based on WireGuard that allows you to easily 
 
 5. After this, you will be taken to the Netbird Dashboard.
 
-    ![Netbird peer](https://raw.githubusercontent.com/eGamesAPI/remnawave-reverse-proxy/refs/heads/main/docs/src/assets/netbird/peer.png)
+    ![Netbird peer](https://raw.githubusercontent.com/eGamesAPI/remnawave-reverse-proxy/refs/heads/main/docs/src/assets/en/netbird/peer.png)
 
 </Steps>
 
@@ -44,13 +44,13 @@ Netbird is an open-source platform based on WireGuard that allows you to easily 
 
 1. Go to the Setup Keys section. Click the Create Setup Key button.
 
-    ![Netbird setup key](https://raw.githubusercontent.com/eGamesAPI/remnawave-reverse-proxy/refs/heads/main/docs/src/assets/netbird/setup_key.png)
+    ![Netbird setup key](https://raw.githubusercontent.com/eGamesAPI/remnawave-reverse-proxy/refs/heads/main/docs/src/assets/en/netbird/setup_key.png)
 
 2. Create the key.
 
     <div style={{ display: 'flex', justifyContent: 'center' }}>
       <img 
-        src="https://raw.githubusercontent.com/eGamesAPI/remnawave-reverse-proxy/refs/heads/main/docs/src/assets/netbird/create_new_setup_key.png" 
+        src="https://raw.githubusercontent.com/eGamesAPI/remnawave-reverse-proxy/refs/heads/main/docs/src/assets/en/netbird/create_new_setup_key.png" 
         alt="Netbird create new setup key" 
         style={{ maxWidth: '60%' }} 
       />
@@ -68,7 +68,7 @@ Netbird is an open-source platform based on WireGuard that allows you to easily 
 
     <div style={{ display: 'flex', justifyContent: 'center' }}>
       <img 
-        src="https://raw.githubusercontent.com/eGamesAPI/remnawave-reverse-proxy/refs/heads/main/docs/src/assets/netbird/key.png" 
+        src="https://raw.githubusercontent.com/eGamesAPI/remnawave-reverse-proxy/refs/heads/main/docs/src/assets/en/netbird/key.png" 
         alt="Netbird key" 
         style={{ maxWidth: '60%' }} 
       />
@@ -88,7 +88,7 @@ Netbird is an open-source platform based on WireGuard that allows you to easily 
 
     <div style={{ display: 'flex', justifyContent: 'center' }}>
       <img 
-        src="https://raw.githubusercontent.com/eGamesAPI/remnawave-reverse-proxy/refs/heads/main/docs/src/assets/netbird/install_netbird.png" 
+        src="https://raw.githubusercontent.com/eGamesAPI/remnawave-reverse-proxy/refs/heads/main/docs/src/assets/en/netbird/install_netbird.png" 
         alt="Netbird create setup key" 
         style={{ maxWidth: '75%' }} 
       />
@@ -100,7 +100,7 @@ Netbird is an open-source platform based on WireGuard that allows you to easily 
     curl -fsSL https://pkgs.netbird.io/install.sh | sh
     ```
 
-    ![Netbird setup](https://raw.githubusercontent.com/eGamesAPI/remnawave-reverse-proxy/refs/heads/main/docs/src/assets/netbird/setup_netbird.png)
+    ![Netbird setup](https://raw.githubusercontent.com/eGamesAPI/remnawave-reverse-proxy/refs/heads/main/docs/src/assets/en/netbird/setup_netbird.png)
 
 3. Start Netbird with the key. Run the command to connect using your saved key:
 
@@ -108,7 +108,7 @@ Netbird is an open-source platform based on WireGuard that allows you to easily 
     netbird up --setup-key AE53280D-88CC-4250-9228-401AB1C7C041
     ```
 
-    ![Netbird setup](https://raw.githubusercontent.com/eGamesAPI/remnawave-reverse-proxy/refs/heads/main/docs/src/assets/netbird/setup_netbird2.png)
+    ![Netbird setup](https://raw.githubusercontent.com/eGamesAPI/remnawave-reverse-proxy/refs/heads/main/docs/src/assets/en/netbird/setup_netbird2.png)
 
 4. Wait for the `Connected` message, indicating a successful connection.
 
@@ -120,7 +120,7 @@ Return to the Dashboard and go to the Peers section.
 
 Ensure that the Remnawave panel peer is shown as connected.
 
-![Netbird peer](https://raw.githubusercontent.com/eGamesAPI/remnawave-reverse-proxy/refs/heads/main/docs/src/assets/netbird/peer_netbird.png)
+![Netbird peer](https://raw.githubusercontent.com/eGamesAPI/remnawave-reverse-proxy/refs/heads/main/docs/src/assets/en/netbird/peer_netbird.png)
 
 ## Installing Netbird on the Node Server
 
@@ -128,7 +128,7 @@ Follow the same installation steps as on the panel server.
 
 Return to the Dashboard and go to the Peers section. Ensure that the node peer is shown as connected.
 
-![Netbird peer](https://raw.githubusercontent.com/eGamesAPI/remnawave-reverse-proxy/refs/heads/main/docs/src/assets/netbird/peer_netbird_node.png)
+![Netbird peer](https://raw.githubusercontent.com/eGamesAPI/remnawave-reverse-proxy/refs/heads/main/docs/src/assets/en/netbird/peer_netbird_node.png)
 
 ## Configuring the Firewall (UFW) on the Node Server
 
@@ -157,7 +157,7 @@ ufw reload
 
     <div style={{ display: 'flex', justifyContent: 'center' }}>
       <img 
-        src="https://raw.githubusercontent.com/eGamesAPI/remnawave-reverse-proxy/refs/heads/main/docs/src/assets/netbird/ip_netbird_node.png" 
+        src="https://raw.githubusercontent.com/eGamesAPI/remnawave-reverse-proxy/refs/heads/main/docs/src/assets/en/netbird/ip_netbird_node.png" 
         alt="Netbird create setup key" 
         style={{ maxWidth: '75%' }} 
       />
@@ -169,7 +169,7 @@ ufw reload
 
 ## Verifying the Connection
 
-![Netbird peer](https://raw.githubusercontent.com/eGamesAPI/remnawave-reverse-proxy/refs/heads/main/docs/src/assets/netbird/ip_netbird_node1.png)
+![Netbird peer](https://raw.githubusercontent.com/eGamesAPI/remnawave-reverse-proxy/refs/heads/main/docs/src/assets/en/netbird/ip_netbird_node1.png)
 
 The node is now connected to the Remnawave panel via Netbird.
 Ensure that the connection between the panel and the node is working (e.g., check access via IP with ping or SSH).


### PR DESCRIPTION
## 🔀 Description of Change

This pull request updates image references in the `docs/src/content/docs/configuration/netbird.mdx` file to remove the `ru` subdirectory from the image paths, standardizing the file structure for assets. The changes ensure consistency and simplify asset management.

### Documentation Updates:
* Updated the image paths in multiple locations to remove the `ru` subdirectory, replacing it with a direct reference to the `netbird` directory for images such as registration, peer setup, keys, and installation. [[1]](diffhunk://#diff-94e20d43e7a35198671809642b1ac02cbbb5dd27c058ab3fbf823346b117856aL25-R25) [[2]](diffhunk://#diff-94e20d43e7a35198671809642b1ac02cbbb5dd27c058ab3fbf823346b117856aL37-R37) [[3]](diffhunk://#diff-94e20d43e7a35198671809642b1ac02cbbb5dd27c058ab3fbf823346b117856aL47-R53) [[4]](diffhunk://#diff-94e20d43e7a35198671809642b1ac02cbbb5dd27c058ab3fbf823346b117856aL71-R71) [[5]](diffhunk://#diff-94e20d43e7a35198671809642b1ac02cbbb5dd27c058ab3fbf823346b117856aL91-R91) [[6]](diffhunk://#diff-94e20d43e7a35198671809642b1ac02cbbb5dd27c058ab3fbf823346b117856aL103-R111) [[7]](diffhunk://#diff-94e20d43e7a35198671809642b1ac02cbbb5dd27c058ab3fbf823346b117856aL123-R131) [[8]](diffhunk://#diff-94e20d43e7a35198671809642b1ac02cbbb5dd27c058ab3fbf823346b117856aL160-R160) [[9]](diffhunk://#diff-94e20d43e7a35198671809642b1ac02cbbb5dd27c058ab3fbf823346b117856aL172-R172)