### PR TITLE
fix: correct cron schedule for certificate renewal

### DIFF
--- a/install_remnawave.sh
+++ b/install_remnawave.sh
@@ -4081,15 +4081,15 @@ handle_certificates() {
         echo -e "${COLOR_YELLOW}${LANG[ADDING_CRON_FOR_EXISTING_CERTS]}${COLOR_RESET}"
         if [ "$min_days_left" -le 30 ]; then
             echo -e "${COLOR_YELLOW}${LANG[CERT_EXPIRY_SOON]} $min_days_left ${LANG[DAYS]}${COLOR_RESET}"
-            add_cron_rule "0 5 * * * $cron_command"
+            add_cron_rule "0 5 * * 0 $cron_command"
         else
-            add_cron_rule "0 5 1 */2 * $cron_command"
+            add_cron_rule "0 5 * * 0 $cron_command"
         fi
-    elif [ "$min_days_left" -le 30 ] && ! crontab -u root -l 2>/dev/null | grep -q "0 5 * * *.*$cron_command"; then
+    elif [ "$min_days_left" -le 30 ] && ! crontab -u root -l 2>/dev/null | grep -q "0 5 * * 0.*$cron_command"; then
         echo -e "${COLOR_YELLOW}${LANG[CERT_EXPIRY_SOON]} $min_days_left ${LANG[DAYS]}${COLOR_RESET}"
         echo -e "${COLOR_YELLOW}${LANG[UPDATING_CRON]}${COLOR_RESET}"
         crontab -u root -l 2>/dev/null | grep -v "/usr/bin/certbot renew" | crontab -u root -
-        add_cron_rule "0 5 * * * $cron_command"
+        add_cron_rule "0 5 * * 0 $cron_command"
     else
         echo -e "${COLOR_YELLOW}${LANG[CRON_ALREADY_EXISTS]}${COLOR_RESET}"
     fi


### PR DESCRIPTION
- Changed cron schedule from daily to weekly
- Updated cron rule to run on every Sunday at 5 AM

## 🔀 Description of Change

* **Change in Certificate Renewal Schedule**
The automated task that renewed the website security certificates daily has been modified. Instead of being refreshed every day, the certificates will now only renew once a week, specifically on Sundays. 

* **Updated Conditions for Existing Scheduled Tasks**
Due to the changes made to the certificate renewal schedule, we had to adjust the conditions that check if these tasks exist and have been performed. The system's current checks are now in line with the new Sunday schedule.


<!-- Thank you for your Pull Request. -->
<!-- DO NOT remove the * **Change in Certificate Renewal Schedule**
The automated task that renewed the website security certificates daily has been modified. Instead of being refreshed every day, the certificates will now only renew once a week, specifically on Sundays. 

* **Updated Conditions for Existing Scheduled Tasks**
Due to the changes made to the certificate renewal schedule, we had to adjust the conditions that check if these tasks exist and have been performed. The system's current checks are now in line with the new Sunday schedule.
 tag above if you want your PR to be summarized by AI. -->

#### 📝 Additional Information

[https://t.me/c/2655959772/17878](https://t.me/c/2655959772/17878)