### PR TITLE
Fix: API token generation error output corrupts docker-compose.yml

### DIFF
--- a/install_remnawave.sh
+++ b/install_remnawave.sh
@@ -4047,7 +4047,7 @@ create_api_token() {
     local api_response=$(make_api_request "POST" "http://$domain_url/api/tokens" "$token" "$token_data")
 
     if [ -z "$api_response" ]; then
-        echo -e "${COLOR_RED}${LANG[ERROR_CREATE_API_TOKEN]}${COLOR_RESET}"
+        echo -e "${COLOR_RED}${LANG[ERROR_CREATE_API_TOKEN]}${COLOR_RESET}" >&2
         return 1
     fi
 
@@ -4056,7 +4056,7 @@ create_api_token() {
         echo "$api_token"
         return 0
     else
-        echo -e "${COLOR_RED}${LANG[ERROR_CREATE_API_TOKEN]}: $(echo "$api_response" | jq -r '.message // "Unknown error"') ${COLOR_RESET}"
+        echo -e "${COLOR_RED}${LANG[ERROR_CREATE_API_TOKEN]}: $(echo "$api_response" | jq -r '.message // "Unknown error"') ${COLOR_RESET}" >&2
         return 1
     fi
 }


### PR DESCRIPTION
### Bug Description
When `create_api_token` fails (e.g. database not ready), it prints the error message to stdout using `echo`.
During installation, this output is captured into the `api_token` variable:
`api_token=$(create_api_token ...)`

Consequently, the script writes the error message (including ANSI color codes) into `docker-compose.yml` as the token value. This causes Docker to fail with:
`yaml: control characters are not allowed`

### The Fix
Redirected error messages in `create_api_token` to stderr (`>&2`).
Now, if the function fails, the `api_token` variable will remain empty, preventing the script from writing garbage into the config file.

Thank u 4 your project
Best wishes 