### PR TITLE
Add comment to ufw rule 2222

### DIFF
--- a/install_remnawave.sh
+++ b/install_remnawave.sh
@@ -1437,7 +1437,7 @@ open_panel_access() {
     docker compose up -d remnawave-nginx > /dev/null 2>&1 &
     spinner $! "${LANG[WAITING]}"
     
-    ufw allow from 0.0.0.0/0 to any port 8443 proto tcp > /dev/null 2>&1
+    ufw allow from 0.0.0.0/0 to any port 8443 proto tcp comment "PANEL_CONNECT" > /dev/null 2>&1
     ufw reload > /dev/null 2>&1
     sleep 1
 


### PR DESCRIPTION
## 🔀 Description of Change

* **Improved Code Legibility for Firewall Access**
A descriptive comment has been added to a crucial part of the code that manages network firewall settings. This should help future developers understand the purpose of this particular command, labelled as "PANEL_CONNECT".
* **Code Formatting Adjustment**
We've ensured all coding best practices are followed, one of which is the inclusion of a newline at the end of our files. This might seem insignificant but it helps in maintaining consistency and eliminating potential issues that might occur from their absence.
Add UFW rule comment support for panel connection

This PR adds a comment to the UFW rule that allows access to port 2222.
The comment improves firewall rule readability and simplifies maintenance.