### PR TITLE
fix: stop reporting a config profile as correct when it could not be read

### DIFF
--- a/src/modules/manage_panel.sh
+++ b/src/modules/manage_panel.sh
@@ -527,7 +527,7 @@ set_reality_min_client_ver() {
         return 0
     fi
 
-    local uuid profile missing preset config body response
+    local uuid profile current missing preset config body response
     local patched=0
     local untouched=0
     local failed=0
@@ -537,23 +537,32 @@ set_reality_min_client_ver() {
         [ -n "$uuid" ] || continue
 
         profile=$(make_api_request "GET" "http://$domain_url/api/config-profiles/$uuid" "$token")
-        if ! echo "$profile" | jq -e '.response.config' > /dev/null 2>&1; then
+
+        # The contract declares config as unknown, and a panel may hand it back
+        # as a JSON string instead of an object. Normalise once, and treat a jq
+        # failure here as a failure: folding it into "nothing to do" reports a
+        # profile as already correct while it was never even read.
+        if ! current=$(echo "$profile" | jq -e 'if (.response.config | type) == "string" then (.response.config | fromjson) else .response.config end' 2>/dev/null); then
             failed=$((failed + 1))
             printf "${COLOR_RED}${LANG[MINCLIENTVER_PROFILE_FAILED]}${COLOR_RESET}\n" "$uuid"
             continue
         fi
 
-        missing=$(echo "$profile" | jq '[.response.config.inbounds[]? | select(.streamSettings.security? == "reality") | select((.streamSettings.realitySettings | type) == "object") | select(.streamSettings.realitySettings | has("minClientVer") | not)] | length')
-        preset=$(echo "$profile" | jq '[.response.config.inbounds[]? | select(.streamSettings.security? == "reality") | select((.streamSettings.realitySettings.minClientVer? // "0.0.0") != "0.0.0")] | length')
+        if ! missing=$(echo "$current" | jq -e '[.inbounds[]? | select(.streamSettings.security? == "reality") | select((.streamSettings.realitySettings | type) == "object") | select(.streamSettings.realitySettings | has("minClientVer") | not)] | length' 2>/dev/null); then
+            failed=$((failed + 1))
+            printf "${COLOR_RED}${LANG[MINCLIENTVER_PROFILE_FAILED]}${COLOR_RESET}\n" "$uuid"
+            continue
+        fi
+
+        preset=$(echo "$current" | jq '[.inbounds[]? | select(.streamSettings.security? == "reality") | select((.streamSettings.realitySettings.minClientVer? // "0.0.0") != "0.0.0")] | length' 2>/dev/null)
         [ -n "$preset" ] && [ "$preset" != "0" ] && custom=$((custom + 1))
 
-        if [ -z "$missing" ] || [ "$missing" = "0" ]; then
+        if [ "$missing" = "0" ]; then
             untouched=$((untouched + 1))
             continue
         fi
 
-        config=$(echo "$profile" | jq '.response.config | .inbounds |= map(if (.streamSettings.security? == "reality") and ((.streamSettings.realitySettings | type) == "object") then (.streamSettings.realitySettings.minClientVer //= "0.0.0") else . end)')
-        if [ -z "$config" ]; then
+        if ! config=$(echo "$current" | jq -e '.inbounds |= map(if (.streamSettings.security? == "reality") and ((.streamSettings.realitySettings | type) == "object") then (.streamSettings.realitySettings.minClientVer //= "0.0.0") else . end)' 2>/dev/null); then
             failed=$((failed + 1))
             printf "${COLOR_RED}${LANG[MINCLIENTVER_PROFILE_FAILED]}${COLOR_RESET}\n" "$uuid"
             continue


### PR DESCRIPTION
## 🔀 Description of Change

* **Improvement in Clarity of Code**
The variable name has been switched from `config` to `current` to make the code easier to understand.

* **Enhancement in JSON Processing**
The logic for how JSON data is handled has been improved to cope with situations where `config` might appear as a string instead of an object. 

* **Boosting Robustness with Error Handling**
Additional error handling measures have been implemented during JSON parsing. This should help ensure that problems are reported more accurately if they occur.

* **Streamlined Operations Improve Efficiency**
The process for checking a variable called `missing` has been streamlined, removing unnecessary efforts in checking variable assignments. This could result in faster processing.

* **Configuration Updates Made More Efficient**
The process for updating configuration is now more efficient, as several operations have been combined into a single command. This should help make changes faster and more accurately.

A user selected **Set REALITY minClientVer in config profiles**, the action reported success, and the field was not there afterwards — he ended up adding it to his config by hand.

### What happens

The contract declares the profile config as `z.unknown()`. When a panel hands it back as a JSON **string** rather than an object, the guard passes and the detector below it does not:

```
jq: error (at <stdin>:1): Cannot index string with string "inbounds"
```

`jq -e '.response.config'` is true for any non-empty string, so the profile is accepted. The detector then fails, `missing` comes back empty, and the next line reads:

```bash
if [ -z "$missing" ] || [ "$missing" = "0" ]; then
    untouched=$((untouched + 1))
    continue
```

So a profile that could not be read at all is counted as *already correct*, no PATCH is sent, and the summary prints `failed: 0`. The same hole swallows any other jq failure on that line.

### Reproduction

Through the real function with a mocked panel, using the config the reporting user posted:

| code | config as | result |
|---|---|---|
| current `main` | string | `patched=0 untouched=1 failed=0` — no PATCH sent |
| current `main` | object | `patched=1` |
| this PR | either | `patched=1`, `minClientVer: "0.0.0"` in the PATCH body |

### The change

Normalise the config once — parsing it with `fromjson` when it arrives as a string — and check jq's exit status at each of the three steps instead of inferring intent from an empty variable. A profile that cannot be read is counted as failed and its uuid printed, so it is visible rather than silently green.

16 insertions, 7 deletions, one file.

### Note

This is separate from #166. That one stops a failed module load from terminating the script, which is the other half of the same user's report (the entry printed its first line and the script closed). Either can be merged without the other.
